### PR TITLE
feat: 通知基盤を拡張し、GitHub Actions 定期実行と運用ドキュメントを整備

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,29 @@
 # Bangumi person ID to monitor (e.g., 12345)
 TARGET_BANGUMI_ID=
 
-# Animator name for Sakuga@wiki search
+# Animator name for AniList search
 TARGET_NAME=
+
+# Notification backend: console | email | line
+NOTIFIER=console
+# Optional multi-target fanout (comma-separated): e.g. email,line
+NOTIFIERS=
+
+# ---- Email notifier settings (required when NOTIFIER=email) ----
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_FROM=
+SMTP_TO=
+SMTP_USER=
+SMTP_PASS=
+SMTP_USE_TLS=true
+# Optional templates (variables: {title}, {message})
+EMAIL_SUBJECT_TEMPLATE=[ACM] {title}
+EMAIL_BODY_TEMPLATE={title}\n\n{message}
+
+# ---- LINE notifier settings (required when NOTIFIER=line) ----
+LINE_NOTIFY_TOKEN=
+# Optional override
+LINE_NOTIFY_API_URL=https://notify-api.line.me/api/notify
+# Optional template (variables: {title}, {message})
+LINE_MESSAGE_TEMPLATE={title}\n{message}

--- a/.github/workflows/daily-credit-check.yml
+++ b/.github/workflows/daily-credit-check.yml
@@ -1,0 +1,46 @@
+name: Daily Credit Check
+
+on:
+  schedule:
+    # 09:00 JST = 00:00 UTC
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rye
+        uses: eifinger/setup-rye@v4
+
+      - name: Install dependencies
+        run: rye sync
+
+      - name: Run credit monitor
+        env:
+          TARGET_BANGUMI_ID: ${{ secrets.TARGET_BANGUMI_ID }}
+          TARGET_NAME: ${{ secrets.TARGET_NAME }}
+
+          # Notification backend: console | email | line
+          NOTIFIER: ${{ secrets.NOTIFIER }}
+          NOTIFIERS: ${{ secrets.NOTIFIERS }}
+
+          # Email notifier settings (when NOTIFIER=email)
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_FROM: ${{ secrets.SMTP_FROM }}
+          SMTP_TO: ${{ secrets.SMTP_TO }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          SMTP_USE_TLS: ${{ secrets.SMTP_USE_TLS }}
+          EMAIL_SUBJECT_TEMPLATE: ${{ secrets.EMAIL_SUBJECT_TEMPLATE }}
+          EMAIL_BODY_TEMPLATE: ${{ secrets.EMAIL_BODY_TEMPLATE }}
+
+          # LINE notifier settings (when NOTIFIER=line)
+          LINE_NOTIFY_TOKEN: ${{ secrets.LINE_NOTIFY_TOKEN }}
+          LINE_NOTIFY_API_URL: ${{ secrets.LINE_NOTIFY_API_URL }}
+          LINE_MESSAGE_TEMPLATE: ${{ secrets.LINE_MESSAGE_TEMPLATE }}
+        run: rye run animator-credit-monitor check

--- a/.github/workflows/daily-credit-check.yml
+++ b/.github/workflows/daily-credit-check.yml
@@ -52,8 +52,9 @@ jobs:
 
           # LINE notifier settings (when NOTIFIER=line)
           LINE_NOTIFY_TOKEN: ${{ secrets.LINE_NOTIFY_TOKEN }}
-          LINE_NOTIFY_API_URL: ${{ secrets.LINE_NOTIFY_API_URL }}
-          LINE_MESSAGE_TEMPLATE: ${{ secrets.LINE_MESSAGE_TEMPLATE }}
+          LINE_NOTIFY_API_URL: ${{ secrets.LINE_NOTIFY_API_URL || 'https://notify-api.line.me/api/notify' }}
+          LINE_MESSAGE_TEMPLATE: ${{ secrets.LINE_MESSAGE_TEMPLATE || '{title}\n{message}' }}
+{message}' }}
           DATA_DIR: data
         run: rye run animator-credit-monitor check
 

--- a/.github/workflows/daily-credit-check.yml
+++ b/.github/workflows/daily-credit-check.yml
@@ -54,7 +54,6 @@ jobs:
           LINE_NOTIFY_TOKEN: ${{ secrets.LINE_NOTIFY_TOKEN }}
           LINE_NOTIFY_API_URL: ${{ secrets.LINE_NOTIFY_API_URL || 'https://notify-api.line.me/api/notify' }}
           LINE_MESSAGE_TEMPLATE: ${{ secrets.LINE_MESSAGE_TEMPLATE || '{title}\n{message}' }}
-{message}' }}
           DATA_DIR: data
         run: rye run animator-credit-monitor check
 

--- a/.github/workflows/daily-credit-check.yml
+++ b/.github/workflows/daily-credit-check.yml
@@ -9,9 +9,20 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Restore history cache
+        id: history-cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: data
+          key: history-${{ github.ref_name }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            history-${{ github.ref_name }}-
 
       - name: Setup Rye
         uses: eifinger/setup-rye@v4
@@ -43,4 +54,15 @@ jobs:
           LINE_NOTIFY_TOKEN: ${{ secrets.LINE_NOTIFY_TOKEN }}
           LINE_NOTIFY_API_URL: ${{ secrets.LINE_NOTIFY_API_URL }}
           LINE_MESSAGE_TEMPLATE: ${{ secrets.LINE_MESSAGE_TEMPLATE }}
+          DATA_DIR: data
         run: rye run animator-credit-monitor check
+
+      - name: Ensure history directory exists
+        run: mkdir -p data
+
+      - name: Save history cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: data
+          key: history-${{ github.ref_name }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/CLAUDE-JP.md
+++ b/CLAUDE-JP.md
@@ -40,23 +40,23 @@ rye run animator-credit-monitor --help      # CLIヘルプ表示
 ```bash
 animator-credit-monitor check               # 全ソースチェック
 animator-credit-monitor check --bangumi-only # Bangumiのみ
-animator-credit-monitor check --anilist-only # AniListのみ
+animator-credit-monitor check --anilist-only # nameベースソースのみ（AniList直利用）
 animator-credit-monitor check --dry-run      # 状態保存なしでチェック
 ```
 
 ## アーキテクチャ
-- **Notifier:** 抽象基底クラス（`Notifier`）に `ConsoleNotifier` をデフォルト実装。新しいサブクラスを実装することでDiscord/メール等に差し替え可能。
+- **Notifier:** 抽象基底クラス（`Notifier`）に `ConsoleNotifier`（デフォルト）、`EmailNotifier`、`LineNotifier` を実装。
 - **Scraper:** 3つのスクレイパークラス:
   - `BangumiScraper` — bangumi.tvの人物作品ページをスクレイプ。`<small>` タグから日本語タイトルを取得し、ない場合は中国語にフォールバック。`title_cn` フィールドを保持。
   - `AniListScraper` — AniList GraphQL API使用（認証不要）。日本語タイトル、ローマ字、役割、日付を返却。
   - `SakugaWikiScraper` — w.atwiki.jp/sakuga を検索（現在Cloudflare 403でブロック中）。
-- **フォールバック:** 作画@wiki失敗時（403）は自動的にAniList APIにフォールバック。
+- **nameベースソースの実動作:** 作画@wiki が403でブロック中のため、nameベースチェックは AniList を直接利用する。作画@wiki スクレイパーは将来復旧に備えて保持。
 - **History:** `HistoryManager` が `data/` 内のJSONベースの状態保存と差分検知を担当。履歴ファイルはソースID付き（例: `bangumi_50763_history.json`）で、アニメーター切替時にデータが混在しない。
 - **Main:** Click CLIがオーケストレーション: 設定読込 → スクレイプ → 差分検知 → 変更があれば通知。
 
 ## 環境変数（.env）
 - `TARGET_BANGUMI_ID` - 監視対象のBangumi人物ID
-- `TARGET_NAME` - AniList/作画@wiki検索用のアニメーター名
+- `TARGET_NAME` - nameベース監視用のアニメーター名（現状は実質AniList）
 
 ## データ形式
 
@@ -67,7 +67,7 @@ animator-credit-monitor check --dry-run      # 状態保存なしでチェック
 
 ### AniList作品
 ```json
-{"id": "180516", "title": "ウマ娘 シンデレラグレイ", "title_romaji": "Uma Musume: Cinderella Gray", "role": "Key Animation (OP)", "date": "2025-04"}
+{"id": "180516", "title": "ウマ娘 シンデレラグレイ", "title_romaji": "Uma Musume: Cinderella Gray", "role": "原画 (OP)", "date": "2025-04"}
 ```
 
 ## ドキュメント管理
@@ -82,4 +82,4 @@ animator-credit-monitor check --dry-run      # 状態保存なしでチェック
 - テスト名は日本語: `test_{分かりやすい日本語のシナリオ名}`
 - `responses` ライブラリでHTTPモック
 - `tests/fixtures/` にHTML解析テスト用フィクスチャ配置
-- 全29テストで全モジュールをカバー
+- CLI / scraper / history / notifier モジュールをテストでカバー

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,23 +40,23 @@ rye run animator-credit-monitor --help      # Show CLI help
 ```bash
 animator-credit-monitor check               # Check all sources
 animator-credit-monitor check --bangumi-only # Bangumi only
-animator-credit-monitor check --anilist-only # AniList only
+animator-credit-monitor check --anilist-only # Name-based source only (AniList direct)
 animator-credit-monitor check --dry-run      # Check without saving state
 ```
 
 ## Architecture
-- **Notifier:** Abstract base class (`Notifier`) with `ConsoleNotifier` default implementation. Swap to Discord/email by implementing new subclass.
+- **Notifier:** Abstract base class (`Notifier`) with `ConsoleNotifier` (default), `EmailNotifier`, and `LineNotifier` implementations.
 - **Scraper:** Three scraper classes:
   - `BangumiScraper` — Scrapes bangumi.tv person works page. Returns Japanese titles from `<small>` tag, falling back to Chinese titles. Includes `title_cn` field.
   - `AniListScraper` — Uses AniList GraphQL API (no auth required). Returns Japanese titles, romaji, roles, and dates.
   - `SakugaWikiScraper` — Searches w.atwiki.jp/sakuga (currently blocked by Cloudflare 403).
-- **Fallback:** When Sakuga@wiki fails (403), automatically falls back to AniList API.
+- **Name-based source behavior:** Name-based checks use AniList directly while Sakuga@wiki remains blocked (403). Sakuga@wiki scraper code is kept only for possible future recovery.
 - **History:** `HistoryManager` handles JSON-based state persistence in `data/` and diff detection. History files are named with source ID (e.g., `bangumi_50763_history.json`) to avoid mixing data when switching animators.
 - **Main:** Click CLI orchestrates: load config → scrape → detect diff → notify if changes found.
 
 ## Environment Variables (.env)
 - `TARGET_BANGUMI_ID` - Bangumi person ID to monitor
-- `TARGET_NAME` - Animator name for AniList/Sakuga@wiki search
+- `TARGET_NAME` - Animator name for name-based monitoring (currently effectively AniList)
 
 ## Data Format
 
@@ -67,7 +67,7 @@ animator-credit-monitor check --dry-run      # Check without saving state
 
 ### AniList works
 ```json
-{"id": "180516", "title": "ウマ娘 シンデレラグレイ", "title_romaji": "Uma Musume: Cinderella Gray", "role": "Key Animation (OP)", "date": "2025-04"}
+{"id": "180516", "title": "ウマ娘 シンデレラグレイ", "title_romaji": "Uma Musume: Cinderella Gray", "role": "原画 (OP)", "date": "2025-04"}
 ```
 
 ## Documentation
@@ -82,4 +82,4 @@ animator-credit-monitor check --dry-run      # Check without saving state
 - Test names in Japanese: `test_{descriptive_scenario_in_Japanese}`
 - HTTP mocking with `responses` library
 - Fixtures in `tests/fixtures/` for HTML parsing tests
-- 29 tests covering all modules
+- Tests cover CLI, scraper, history, and notifier modules

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 | Source | URL | Description |
 |---|---|---|
 | Bangumi | `bangumi.tv/person/{ID}` | 中国のアニメデータベース。作品リスト (Filmography) の差分を監視 |
-| 作画@wiki | `w.atwiki.jp/sakuga/` | 日本の作画情報 wiki。キーワード検索結果を監視 |
+| AniList | `graphql.anilist.co` | スタッフクレジットを API 経由で取得して差分監視 |
+| 作画@wiki | `w.atwiki.jp/sakuga/` | 日本の作画情報 wiki。※現在は Cloudflare 403 により実運用では利用不可 |
 
 ## Setup
 
@@ -38,8 +39,30 @@ Edit `.env`:
 # Bangumi person ID (find it from the URL: bangumi.tv/person/{THIS_NUMBER})
 TARGET_BANGUMI_ID=12345
 
-# Animator name for Sakuga@wiki search
+# Animator name for AniList search
 TARGET_NAME=アニメーター名
+
+# Notification backend: console | email | line
+NOTIFIER=console
+
+# Email notifier settings (required when NOTIFIER=email)
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_FROM=from@example.com
+SMTP_TO=to@example.com
+SMTP_USER=
+SMTP_PASS=
+SMTP_USE_TLS=true
+# Optional templates (variables: {title}, {message})
+EMAIL_SUBJECT_TEMPLATE=[ACM] {title}
+EMAIL_BODY_TEMPLATE={title}\n\n{message}
+
+# LINE notifier settings (required when NOTIFIER=line)
+LINE_NOTIFY_TOKEN=your_token
+# Optional
+LINE_NOTIFY_API_URL=https://notify-api.line.me/api/notify
+# Optional template (variables: {title}, {message})
+LINE_MESSAGE_TEMPLATE={title}\n{message}
 ```
 
 ## Usage
@@ -59,15 +82,123 @@ rye run animator-credit-monitor check --dry-run
 # Check only Bangumi
 rye run animator-credit-monitor check --bangumi-only
 
-# Check only Sakuga@wiki
-rye run animator-credit-monitor check --wiki-only
+# Check only AniList/name-based source
+rye run animator-credit-monitor check --anilist-only
 ```
+
+> 現状メモ: name ベースの監視は AniList を直接利用します。
+> 作画@wiki は現在 403 のため、運用対象から外しています。
 
 ### Show help
 
 ```bash
 rye run animator-credit-monitor --help
 rye run animator-credit-monitor check --help
+```
+
+## Notifications
+
+- `NOTIFIER=console` (default): print to stdout
+- `NOTIFIER=email`: send via SMTP (`SMTP_*` required)
+- `NOTIFIER=line`: send via LINE Notify compatible API (`LINE_NOTIFY_TOKEN` required)
+- `NOTIFIERS=email,line`: fan-out to both email and LINE in one run
+- Message templates can use `{title}` and `{message}` placeholders
+- Example templates are provided under `templates/`:
+  - `templates/email_subject.template.txt`
+  - `templates/email_body.template.txt`
+  - `templates/line_message.template.txt`
+
+### Notification message format
+
+- Title: `新しいクレジット (Bangumi|AniList)`
+- Body:
+  - First line: `検知件数: N`
+  - Following lines: numbered credit entries (`1. ...`, `2. ...`)
+- Templates can use `{title}` and `{message}` to wrap/reformat the standardized payload.
+
+## GitHub Actions (Scheduled Run)
+
+A workflow is provided at `.github/workflows/daily-credit-check.yml`.
+
+1. Open **Settings → Secrets and variables → Actions** in your GitHub repository.
+2. Add required secrets (at minimum):
+   - `TARGET_NAME` (for AniList name-based monitoring)
+   - `NOTIFIER` (`email` or `line`)
+   - or `NOTIFIERS` (`email,line`) to send to both
+3. Add notifier-specific secrets:
+   - Email: `SMTP_HOST`, `SMTP_PORT`, `SMTP_FROM`, `SMTP_TO`, `SMTP_USER`, `SMTP_PASS`, `SMTP_USE_TLS`
+   - LINE: `LINE_NOTIFY_TOKEN` (optional: `LINE_NOTIFY_API_URL`)
+4. Run from **Actions → Daily Credit Check → Run workflow** for first validation.
+
+### Secrets templates (GitHub Actions)
+
+#### Email notifier (`NOTIFIER=email`)
+
+```text
+NOTIFIER=email
+TARGET_NAME=監視対象名
+TARGET_BANGUMI_ID=12345
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_FROM=from@example.com
+SMTP_TO=to@example.com
+SMTP_USER=your_user
+SMTP_PASS=your_password
+SMTP_USE_TLS=true
+EMAIL_SUBJECT_TEMPLATE=[ACM] {title}
+EMAIL_BODY_TEMPLATE={title}\n\n{message}
+```
+
+#### Email notifier (SendGrid preset)
+
+```text
+NOTIFIER=email
+TARGET_NAME=監視対象名
+TARGET_BANGUMI_ID=12345
+SMTP_HOST=smtp.sendgrid.net
+SMTP_PORT=587
+SMTP_USE_TLS=true
+SMTP_FROM=verified-sender@example.com
+SMTP_TO=destination@example.com
+SMTP_USER=apikey
+SMTP_PASS=SG.xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+EMAIL_SUBJECT_TEMPLATE=[ACM] {title}
+EMAIL_BODY_TEMPLATE={title}\n\n{message}
+```
+
+> `SMTP_USER=apikey` + `SMTP_PASS=<SendGrid API key>` がSendGridのSMTP認証セットです。
+> 同じ内容は `templates/sendgrid_github_secrets.template.txt` にもあります。
+
+#### LINE notifier (`NOTIFIER=line`)
+
+```text
+NOTIFIER=line
+TARGET_NAME=監視対象名
+TARGET_BANGUMI_ID=12345
+LINE_NOTIFY_TOKEN=your_token
+LINE_NOTIFY_API_URL=https://notify-api.line.me/api/notify
+LINE_MESSAGE_TEMPLATE={title}\n{message}
+```
+
+#### Email + LINE notifier (both)
+
+```text
+NOTIFIERS=email,line
+TARGET_NAME=監視対象名
+TARGET_BANGUMI_ID=12345
+
+# Email side
+SMTP_HOST=smtp.sendgrid.net
+SMTP_PORT=587
+SMTP_FROM=verified-sender@example.com
+SMTP_TO=destination@example.com
+SMTP_USER=apikey
+SMTP_PASS=SG.xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+SMTP_USE_TLS=true
+
+# LINE side
+LINE_NOTIFY_TOKEN=your_token
+LINE_NOTIFY_API_URL=https://notify-api.line.me/api/notify
 ```
 
 ## Testing

--- a/docs/AUTOMATION-JP.md
+++ b/docs/AUTOMATION-JP.md
@@ -72,3 +72,52 @@ WantedBy=timers.target
 ```bash
 systemctl --user enable --now animator-monitor.timer
 ```
+
+## GitHub Actions（定期実行）
+
+このリポジトリには `.github/workflows/daily-credit-check.yml` を用意している。
+
+### セットアップ
+
+1. GitHub リポジトリの **Settings → Secrets and variables → Actions** を開く。
+2. ワークフローで使う Secrets を登録する:
+   - 監視対象として必要:
+     - `TARGET_NAME`（AniList の name ベース監視）
+     - `TARGET_BANGUMI_ID`（Bangumi も監視する場合は設定）
+   - 通知先選択:
+     - `NOTIFIER`（`console` / `email` / `line`）
+     - `NOTIFIERS`（任意。複数通知先。例: `email,line`）
+   - `NOTIFIER=email` の場合:
+     - `SMTP_HOST`, `SMTP_PORT`, `SMTP_FROM`, `SMTP_TO`
+     - `SMTP_USER`, `SMTP_PASS`（認証が必要な場合）
+     - `SMTP_USE_TLS`（例: `true`）
+     - `EMAIL_SUBJECT_TEMPLATE`, `EMAIL_BODY_TEMPLATE`（任意。`{title}` / `{message}` プレースホルダ対応）
+   - `NOTIFIER=line` の場合:
+     - `LINE_NOTIFY_TOKEN`
+     - `LINE_NOTIFY_API_URL`（任意。未設定時は互換エンドポイントを使用）
+     - `LINE_MESSAGE_TEMPLATE`（任意。`{title}` / `{message}` プレースホルダ対応）
+
+3. **Actions → Daily Credit Check → Run workflow** で手動実行し、初回動作確認を行う。
+
+### 認証情報の扱い
+
+- 認証情報は必ず **GitHub Secrets** に保存する（リポジトリへコミットしない）。
+- ワークフローでは実行時の環境変数としてのみ注入される。
+- 認証情報が不正な場合はCLIが設定/通知エラーを明示して終了する。
+
+
+### SendGrid かんたん設定（`NOTIFIER=email` 用）
+
+SendGrid SMTP で送る場合は、Secrets を次の値で設定するとよい。
+
+```text
+NOTIFIER=email
+SMTP_HOST=smtp.sendgrid.net
+SMTP_PORT=587
+SMTP_USE_TLS=true
+SMTP_USER=apikey
+SMTP_PASS=SG.xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+`SMTP_FROM` は SendGrid 側で認証済みの送信元（Sender Identity / Domain Authentication）を使うこと。
+

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -72,3 +72,52 @@ WantedBy=timers.target
 ```bash
 systemctl --user enable --now animator-monitor.timer
 ```
+
+## GitHub Actions (Scheduled)
+
+This repository includes `.github/workflows/daily-credit-check.yml`.
+
+### Setup
+
+1. Go to **Settings → Secrets and variables → Actions**.
+2. Register secrets used by the workflow:
+   - Required for monitoring target:
+     - `TARGET_NAME` (AniList name-based check)
+     - `TARGET_BANGUMI_ID` (optional if you also monitor Bangumi)
+   - Required notifier selector:
+     - `NOTIFIER` (`console`, `email`, or `line`)
+     - `NOTIFIERS` (optional multi-destination, e.g. `email,line`)
+   - If `NOTIFIER=email`:
+     - `SMTP_HOST`, `SMTP_PORT`, `SMTP_FROM`, `SMTP_TO`
+     - `SMTP_USER`, `SMTP_PASS` (if authentication is required)
+     - `SMTP_USE_TLS` (e.g., `true`)
+     - `EMAIL_SUBJECT_TEMPLATE`, `EMAIL_BODY_TEMPLATE` (optional, `{title}` / `{message}` placeholders)
+   - If `NOTIFIER=line`:
+     - `LINE_NOTIFY_TOKEN`
+     - `LINE_NOTIFY_API_URL` (optional; defaults to LINE Notify compatible endpoint)
+     - `LINE_MESSAGE_TEMPLATE` (optional, `{title}` / `{message}` placeholders)
+
+3. Trigger once manually from **Actions → Daily Credit Check → Run workflow**.
+
+### Authentication Notes
+
+- Keep all credentials in **GitHub Secrets** (never commit into repo files).
+- The workflow passes credentials as runtime environment variables only.
+- If credentials are invalid, the CLI exits with a clear configuration/notification error.
+
+
+### SendGrid quick preset (for `NOTIFIER=email`)
+
+Use these Secrets values when sending via SendGrid SMTP:
+
+```text
+NOTIFIER=email
+SMTP_HOST=smtp.sendgrid.net
+SMTP_PORT=587
+SMTP_USE_TLS=true
+SMTP_USER=apikey
+SMTP_PASS=SG.xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Also set `SMTP_FROM` to a verified sender/domain in SendGrid.
+

--- a/docs/MAINTENANCE-JP.md
+++ b/docs/MAINTENANCE-JP.md
@@ -26,7 +26,9 @@
 | `ul.search-list` | 検索結果コンテナ | `_parse_search_results()` |
 | `li > a` | 結果リンク + タイトル | `_parse_search_results()` |
 
-**注意:** 作画@wiki は現在 Cloudflare にブロックされている（HTTP 403）。User-Agentヘッダーに関係なく全リクエストが403を返す。この場合、システムは自動的に AniList API にフォールバックする。
+**注意:** 作画@wiki は現在 Cloudflare にブロックされている（HTTP 403）。User-Agentヘッダーに関係なく全リクエストが403を返す。
+
+**運用上、name ベース監視は現在 AniList を直接利用する。** 作画@wiki のスクレイピング実装は将来の復旧に備えて残しているが、403が継続している間は通常チェックフローから除外している。
 
 ### AniList (`scraper.py` - `AniListScraper`)
 
@@ -99,6 +101,15 @@ Bangumi は HTTPレスポンスヘッダーに `charset` を設定していな�
 
 文字化けが発生した場合、`scraper.py` にこのエンコーディングオーバーライドが存在するか確認すること。
 
+## 通知バックエンド
+
+実装済み・今後実装予定の通知先は以下。
+
+- **ConsoleNotifier**（実装済み）: 標準出力。ローカル開発向け。
+- **EmailNotifier**（実装済み）: `SMTP_*` 環境変数でSMTP送信。`EMAIL_SUBJECT_TEMPLATE` / `EMAIL_BODY_TEMPLATE` に対応。
+- **LineNotifier**（実装済み）: `LINE_NOTIFY_TOKEN` を使った LINE Notify 互換 API 送信。`LINE_MESSAGE_TEMPLATE` に対応。
+- **Discord/Slack webhook**（未実装）: チーム運用向けの次候補。
+
 ## 新しい通知バックエンドの追加
 
 1. `src/animator_credit_monitor/notifier.py` で `Notifier` を継承した新しいクラスを作成:
@@ -123,3 +134,14 @@ rye run ruff check src/ tests/    # lint チェック
 rye run ruff check --fix src/ tests/  # lint 自動修正
 rye run mypy src/                 # 型チェック
 ```
+
+## 通知メッセージ形式
+
+現在の通知ペイロード方針:
+
+- タイトル: ソース別（`新しいクレジット (Bangumi)` / `新しいクレジット (AniList)`）
+- 本文1行目: 検知件数（`検知件数: N`）
+- 本文2行目以降: 連番付きエントリ（役職/日付/付帯情報を付与）
+
+この標準化ペイロードを全 notifier に渡し、必要に応じて `{title}` / `{message}` テンプレートでチャネル別整形を行う。
+

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -26,7 +26,9 @@ The scraper depends on the following CSS selectors. If Bangumi changes their HTM
 | `ul.search-list` | Search results container | `_parse_search_results()` |
 | `li > a` | Result link + title | `_parse_search_results()` |
 
-**Note:** Sakuga@wiki is currently blocked by Cloudflare (HTTP 403). All requests return 403 regardless of User-Agent headers. When this happens, the system automatically falls back to AniList API.
+**Note:** Sakuga@wiki is currently blocked by Cloudflare (HTTP 403). All requests return 403 regardless of User-Agent headers.
+
+**Operationally, name-based monitoring now uses AniList directly.** Sakuga@wiki scraping code remains for reference/possible future recovery, but it is excluded from the normal check flow while 403 persists.
 
 ### AniList (`scraper.py` - `AniListScraper`)
 
@@ -99,6 +101,15 @@ Bangumi does not set `charset` in its HTTP response headers, causing `requests` 
 
 If garbled text appears, check that this encoding override is still present in `scraper.py`.
 
+## Notification Backends
+
+Implemented and planned backends:
+
+- **ConsoleNotifier** (implemented): stdout output, useful for local/dev runs.
+- **EmailNotifier** (implemented): SMTP delivery via `SMTP_*` environment variables. Supports `EMAIL_SUBJECT_TEMPLATE` and `EMAIL_BODY_TEMPLATE`.
+- **LineNotifier** (implemented): LINE Notify compatible API via `LINE_NOTIFY_TOKEN`. Supports `LINE_MESSAGE_TEMPLATE`.
+- **Discord/Slack webhook** (planned): recommended next step for team operations.
+
 ## Adding a New Notification Backend
 
 1. Create a new class that inherits from `Notifier` in `src/animator_credit_monitor/notifier.py`:
@@ -123,3 +134,14 @@ rye run ruff check src/ tests/    # Lint check
 rye run ruff check --fix src/ tests/  # Auto-fix lint issues
 rye run mypy src/                 # Type check
 ```
+
+## Notification Message Format
+
+Current payload policy:
+
+- Title: source-specific (`新しいクレジット (Bangumi)` / `新しいクレジット (AniList)`)
+- Body first line: detected count (`検知件数: N`)
+- Body following lines: numbered entries with role/date/info metadata
+
+This standardized payload is passed to all notifier backends. Each backend can further wrap it via template variables `{title}` and `{message}`.
+

--- a/src/animator_credit_monitor/main.py
+++ b/src/animator_credit_monitor/main.py
@@ -105,6 +105,10 @@ def check(dry_run: bool, bangumi_only: bool, anilist_only: bool) -> None:
     """Check for new animation credits."""
     setup_logging()
 
+    if bangumi_only and anilist_only:
+        click.echo("Error: --bangumi-only and --anilist-only cannot be used together")
+        sys.exit(1)
+
     bangumi_id = os.environ.get("TARGET_BANGUMI_ID", "")
     target_name = os.environ.get("TARGET_NAME", "")
     data_dir = os.environ.get("DATA_DIR", "data")

--- a/src/animator_credit_monitor/main.py
+++ b/src/animator_credit_monitor/main.py
@@ -69,7 +69,7 @@ def _build_email_notifier_from_env() -> EmailNotifier:
 
 def _build_line_notifier_from_env() -> LineNotifier:
     token = os.environ.get("LINE_NOTIFY_TOKEN", "").strip()
-    api_url = os.environ.get("LINE_NOTIFY_API_URL", "https://notify-api.line.me/api/notify").strip()
+    api_url = os.environ.get("LINE_NOTIFY_API_URL", "").strip() or "https://notify-api.line.me/api/notify"
     message_template = os.environ.get("LINE_MESSAGE_TEMPLATE", "{title}\n{message}")
     if not token:
         raise ValueError("LINE_NOTIFY_TOKEN is required when using line notifier")

--- a/src/animator_credit_monitor/main.py
+++ b/src/animator_credit_monitor/main.py
@@ -7,8 +7,8 @@ import click
 from dotenv import load_dotenv
 
 from animator_credit_monitor.history import HistoryManager
-from animator_credit_monitor.notifier import ConsoleNotifier
-from animator_credit_monitor.scraper import AniListScraper, BangumiScraper, SakugaWikiScraper
+from animator_credit_monitor.notifier import ConsoleNotifier, EmailNotifier, LineNotifier, MultiNotifier, Notifier
+from animator_credit_monitor.scraper import AniListScraper, BangumiScraper
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +24,77 @@ def setup_logging() -> None:
 def cli() -> None:
     """Animator Credit Monitor - detect new animation credits."""
     load_dotenv()
+
+
+def _parse_notifier_types() -> list[str]:
+    raw_multi = os.environ.get("NOTIFIERS", "").strip()
+    if raw_multi:
+        return [v.strip().lower() for v in raw_multi.split(",") if v.strip()]
+
+    raw_single = os.environ.get("NOTIFIER", "console").strip().lower()
+    return [raw_single]
+
+
+def _build_email_notifier_from_env() -> EmailNotifier:
+    host = os.environ.get("SMTP_HOST", "").strip()
+    port = os.environ.get("SMTP_PORT", "587").strip()
+    from_addr = os.environ.get("SMTP_FROM", "").strip()
+    to_addr = os.environ.get("SMTP_TO", "").strip()
+    username = os.environ.get("SMTP_USER", "").strip()
+    password = os.environ.get("SMTP_PASS", "").strip()
+    use_tls = os.environ.get("SMTP_USE_TLS", "true").strip().lower() in {"1", "true", "yes", "on"}
+    subject_template = os.environ.get("EMAIL_SUBJECT_TEMPLATE", "{title}")
+    body_template = os.environ.get("EMAIL_BODY_TEMPLATE", "{message}")
+
+    if not host or not from_addr or not to_addr:
+        raise ValueError("SMTP_HOST, SMTP_FROM, SMTP_TO are required when using email notifier")
+
+    try:
+        port_num = int(port)
+    except ValueError as e:
+        raise ValueError("SMTP_PORT must be an integer") from e
+
+    return EmailNotifier(
+        host=host,
+        port=port_num,
+        from_addr=from_addr,
+        to_addr=to_addr,
+        username=username,
+        password=password,
+        use_tls=use_tls,
+        subject_template=subject_template,
+        body_template=body_template,
+    )
+
+
+def _build_line_notifier_from_env() -> LineNotifier:
+    token = os.environ.get("LINE_NOTIFY_TOKEN", "").strip()
+    api_url = os.environ.get("LINE_NOTIFY_API_URL", "https://notify-api.line.me/api/notify").strip()
+    message_template = os.environ.get("LINE_MESSAGE_TEMPLATE", "{title}\n{message}")
+    if not token:
+        raise ValueError("LINE_NOTIFY_TOKEN is required when using line notifier")
+    return LineNotifier(token=token, api_url=api_url, message_template=message_template)
+
+
+def _build_notifier_from_env() -> Notifier:
+    notifier_types = _parse_notifier_types()
+    if not notifier_types:
+        raise ValueError("NOTIFIERS is empty")
+
+    notifiers: list[Notifier] = []
+    for notifier_type in notifier_types:
+        if notifier_type == "console":
+            notifiers.append(ConsoleNotifier())
+        elif notifier_type == "email":
+            notifiers.append(_build_email_notifier_from_env())
+        elif notifier_type == "line":
+            notifiers.append(_build_line_notifier_from_env())
+        else:
+            raise ValueError("Notifier type must be one of: console, email, line")
+
+    if len(notifiers) == 1:
+        return notifiers[0]
+    return MultiNotifier(notifiers)
 
 
 @cli.command()
@@ -50,8 +121,13 @@ def check(dry_run: bool, bangumi_only: bool, anilist_only: bool) -> None:
         click.echo("Error: TARGET_NAME must be set for --anilist-only")
         sys.exit(1)
 
+    try:
+        notifier = _build_notifier_from_env()
+    except ValueError as e:
+        click.echo(f"Error: {e}")
+        sys.exit(1)
+
     history = HistoryManager(data_dir=Path(data_dir))
-    notifier = ConsoleNotifier()
     found_new = False
 
     # Bangumi check
@@ -73,47 +149,37 @@ def check(dry_run: bool, bangumi_only: bool, anilist_only: bool) -> None:
         else:
             click.echo("  No data retrieved from Bangumi.")
 
-    # AniList check (with Sakuga@wiki fallback attempt)
+    # Name-based check (AniList direct)
     if not bangumi_only and target_name:
-        # Try Sakuga@wiki first, fall back to AniList
-        click.echo(f"Checking Sakuga@wiki (name: {target_name})...")
-        scraper_wiki = SakugaWikiScraper()
-        results = scraper_wiki.search(target_name)
+        click.echo(f"Checking AniList (name: {target_name})...")
+        scraper_anilist = AniListScraper()
+        results = scraper_anilist.fetch_works(target_name)
 
         if results:
-            source_label = "作画@wiki"
-            source_key = f"sakugawiki_{target_name}"
-        else:
-            click.echo("  Sakuga@wiki unavailable, falling back to AniList...")
-            scraper_anilist = AniListScraper()
-            results = scraper_anilist.fetch_works(target_name)
-            source_label = "AniList"
             source_key = f"anilist_{target_name}"
-
-        if results:
             diff = history.detect_diff(source_key, results)
             if diff:
                 found_new = True
                 notifier.notify(
-                    f"新しいクレジット ({source_label})",
-                    _format_anilist_diff(diff) if source_label == "AniList" else _format_wiki_diff(diff),
+                    "新しいクレジット (AniList)",
+                    _format_anilist_diff(diff),
                 )
             if not dry_run:
                 history.save(source_key, results)
         else:
-            click.echo(f"  No data retrieved from {source_label}.")
+            click.echo("  No data retrieved from AniList.")
 
     if not found_new:
         click.echo("No new credits found.")
 
 
 def _format_bangumi_diff(diff: list[dict]) -> str:
-    lines = []
-    for item in diff:
+    lines = [f"検知件数: {len(diff)}"]
+    for i, item in enumerate(diff, start=1):
         title = item.get("title", "Unknown")
         role = item.get("role", "")
         info = item.get("info", "")
-        line = f"  - {title}"
+        line = f"{i}. {title}"
         if role:
             line += f" [{role}]"
         if info:
@@ -122,25 +188,13 @@ def _format_bangumi_diff(diff: list[dict]) -> str:
     return "\n".join(lines)
 
 
-def _format_wiki_diff(diff: list[dict]) -> str:
-    lines = []
-    for item in diff:
-        title = item.get("title", "Unknown")
-        url = item.get("url", "")
-        line = f"  - {title}"
-        if url:
-            line += f" ({url})"
-        lines.append(line)
-    return "\n".join(lines)
-
-
 def _format_anilist_diff(diff: list[dict]) -> str:
-    lines = []
-    for item in diff:
+    lines = [f"検知件数: {len(diff)}"]
+    for i, item in enumerate(diff, start=1):
         title = item.get("title", "Unknown")
         role = item.get("role", "")
         date = item.get("date", "")
-        line = f"  - {title}"
+        line = f"{i}. {title}"
         if role:
             line += f" [{role}]"
         if date:

--- a/src/animator_credit_monitor/notifier.py
+++ b/src/animator_credit_monitor/notifier.py
@@ -1,4 +1,16 @@
+import smtplib
 from abc import ABC, abstractmethod
+from email.message import EmailMessage
+
+import requests
+
+
+def _render_template(template: str, title: str, message: str) -> str:
+    try:
+        return template.format(title=title, message=message)
+    except KeyError as e:
+        missing = e.args[0]
+        raise ValueError(f"Unknown template variable: {missing}") from e
 
 
 class Notifier(ABC):
@@ -10,3 +22,68 @@ class Notifier(ABC):
 class ConsoleNotifier(Notifier):
     def notify(self, title: str, message: str) -> None:
         print(f"[{title}] {message}")
+
+
+class MultiNotifier(Notifier):
+    def __init__(self, notifiers: list[Notifier]) -> None:
+        self._notifiers = notifiers
+
+    def notify(self, title: str, message: str) -> None:
+        for notifier in self._notifiers:
+            notifier.notify(title, message)
+
+
+class EmailNotifier(Notifier):
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        from_addr: str,
+        to_addr: str,
+        username: str = "",
+        password: str = "",
+        use_tls: bool = True,
+        subject_template: str = "{title}",
+        body_template: str = "{message}",
+    ) -> None:
+        self._host = host
+        self._port = port
+        self._from_addr = from_addr
+        self._to_addr = to_addr
+        self._username = username
+        self._password = password
+        self._use_tls = use_tls
+        self._subject_template = subject_template
+        self._body_template = body_template
+
+    def notify(self, title: str, message: str) -> None:
+        msg = EmailMessage()
+        msg["Subject"] = _render_template(self._subject_template, title, message)
+        msg["From"] = self._from_addr
+        msg["To"] = self._to_addr
+        msg.set_content(_render_template(self._body_template, title, message))
+
+        with smtplib.SMTP(self._host, self._port, timeout=30) as smtp:
+            if self._use_tls:
+                smtp.starttls()
+            if self._username and self._password:
+                smtp.login(self._username, self._password)
+            smtp.send_message(msg)
+
+
+class LineNotifier(Notifier):
+    def __init__(
+        self,
+        token: str,
+        api_url: str = "https://notify-api.line.me/api/notify",
+        message_template: str = "{title}\n{message}",
+    ) -> None:
+        self._token = token
+        self._api_url = api_url
+        self._message_template = message_template
+
+    def notify(self, title: str, message: str) -> None:
+        payload = {"message": _render_template(self._message_template, title, message)}
+        headers = {"Authorization": f"Bearer {self._token}"}
+        resp = requests.post(self._api_url, data=payload, headers=headers, timeout=30)
+        resp.raise_for_status()

--- a/src/animator_credit_monitor/notifier.py
+++ b/src/animator_credit_monitor/notifier.py
@@ -5,9 +5,18 @@ from email.message import EmailMessage
 import requests
 
 
+def _decode_template_escapes(template: str) -> str:
+    return (
+        template.replace(r"\r\n", "\r\n")
+        .replace(r"\n", "\n")
+        .replace(r"\r", "\r")
+        .replace(r"\t", "\t")
+    )
+
+
 def _render_template(template: str, title: str, message: str) -> str:
     try:
-        return template.format(title=title, message=message)
+        return _decode_template_escapes(template).format(title=title, message=message)
     except KeyError as e:
         missing = e.args[0]
         raise ValueError(f"Unknown template variable: {missing}") from e

--- a/templates/email_body.template.txt
+++ b/templates/email_body.template.txt
@@ -1,0 +1,6 @@
+{title}
+
+{message}
+
+--
+Animator Credit Monitor

--- a/templates/email_subject.template.txt
+++ b/templates/email_subject.template.txt
@@ -1,0 +1,1 @@
+[Animator Credit Monitor] {title}

--- a/templates/line_message.template.txt
+++ b/templates/line_message.template.txt
@@ -1,0 +1,2 @@
+{title}
+{message}

--- a/templates/sendgrid_github_secrets.template.txt
+++ b/templates/sendgrid_github_secrets.template.txt
@@ -1,0 +1,25 @@
+# GitHub Actions Secrets template for SendGrid SMTP
+# Set NOTIFIER=email to enable email notifications
+
+NOTIFIER=email
+TARGET_NAME=監視対象名
+TARGET_BANGUMI_ID=12345
+
+# SendGrid SMTP connection
+SMTP_HOST=smtp.sendgrid.net
+SMTP_PORT=587
+SMTP_USE_TLS=true
+
+# Email addresses
+SMTP_FROM=verified-sender@example.com
+SMTP_TO=destination@example.com
+
+# SendGrid auth
+# SMTP_USER is usually "apikey"
+SMTP_USER=apikey
+# SMTP_PASS is your SendGrid API key value (starts with SG.)
+SMTP_PASS=SG.xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Optional templates
+EMAIL_SUBJECT_TEMPLATE=[ACM] {title}
+EMAIL_BODY_TEMPLATE={title}\n\n{message}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -203,6 +203,41 @@ class TestCLI:
             message_template="{title}\n{message}",
         )
 
+    @patch("animator_credit_monitor.main.LineNotifier")
+    @patch("animator_credit_monitor.main.AniListScraper")
+    @patch("animator_credit_monitor.main.BangumiScraper")
+    @patch("animator_credit_monitor.main.HistoryManager")
+    def test_NOTIFIER_line設定でAPI_URLが空文字でもデフォルトURLを使う(
+        self,
+        mock_history_cls: MagicMock,
+        mock_bangumi_cls: MagicMock,
+        mock_anilist_cls: MagicMock,
+        mock_line_notifier_cls: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        mock_history_cls.return_value.detect_diff.return_value = []
+        mock_bangumi_cls.return_value.fetch_works.return_value = []
+        mock_anilist_cls.return_value.fetch_works.return_value = []
+
+        env = {
+            "TARGET_BANGUMI_ID": "12345",
+            "TARGET_NAME": "テスト",
+            "DATA_DIR": str(tmp_path),
+            "NOTIFIER": "line",
+            "LINE_NOTIFY_TOKEN": "token",
+            "LINE_NOTIFY_API_URL": "",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            result = runner.invoke(cli, ["check"])
+
+        assert result.exit_code == 0
+        mock_line_notifier_cls.assert_called_once_with(
+            token="token",
+            api_url="https://notify-api.line.me/api/notify",
+            message_template="{title}\n{message}",
+        )
+
     @patch("animator_credit_monitor.main.MultiNotifier")
     @patch("animator_credit_monitor.main.LineNotifier")
     @patch("animator_credit_monitor.main.EmailNotifier")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -107,6 +107,20 @@ class TestCLI:
         assert result.exit_code == 0
         mock_anilist_cls.return_value.fetch_works.assert_not_called()
 
+    def test_bangumi_onlyとanilist_only同時指定はエラー終了する(
+        self,
+        runner: CliRunner,
+    ) -> None:
+        env = {
+            "TARGET_BANGUMI_ID": "12345",
+            "TARGET_NAME": "テスト",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            result = runner.invoke(cli, ["check", "--bangumi-only", "--anilist-only"])
+
+        assert result.exit_code != 0
+        assert "--bangumi-only and --anilist-only" in result.output
+
     @patch("animator_credit_monitor.main.AniListScraper")
     @patch("animator_credit_monitor.main.BangumiScraper")
     @patch("animator_credit_monitor.main.HistoryManager")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -23,17 +23,15 @@ class TestCLI:
             result = runner.invoke(cli, ["check"])
 
         assert result.exit_code != 0
-        assert "TARGET_BANGUMI_ID" in result.output or "設定" in result.output
+        assert "TARGET_BANGUMI_ID" in result.output
 
     @patch("animator_credit_monitor.main.AniListScraper")
-    @patch("animator_credit_monitor.main.SakugaWikiScraper")
     @patch("animator_credit_monitor.main.BangumiScraper")
     @patch("animator_credit_monitor.main.HistoryManager")
     def test_差分がある場合に通知が呼ばれる(
         self,
         mock_history_cls: MagicMock,
         mock_bangumi_cls: MagicMock,
-        mock_wiki_cls: MagicMock,
         mock_anilist_cls: MagicMock,
         runner: CliRunner,
         tmp_path: Path,
@@ -41,14 +39,10 @@ class TestCLI:
         mock_history = mock_history_cls.return_value
         mock_history.detect_diff.return_value = [{"id": "1", "title": "新作品", "role": "原画", "info": "2026-01"}]
 
-        mock_bangumi = mock_bangumi_cls.return_value
-        mock_bangumi.fetch_works.return_value = [{"id": "1", "title": "新作品", "role": "原画", "info": "2026-01"}]
-
-        mock_wiki = mock_wiki_cls.return_value
-        mock_wiki.search.return_value = []
-
-        mock_anilist = mock_anilist_cls.return_value
-        mock_anilist.fetch_works.return_value = []
+        mock_bangumi_cls.return_value.fetch_works.return_value = [
+            {"id": "1", "title": "新作品", "role": "原画", "info": "2026-01"},
+        ]
+        mock_anilist_cls.return_value.fetch_works.return_value = []
 
         env = {
             "TARGET_BANGUMI_ID": "12345",
@@ -62,65 +56,20 @@ class TestCLI:
         assert "新作品" in result.output
 
     @patch("animator_credit_monitor.main.AniListScraper")
-    @patch("animator_credit_monitor.main.SakugaWikiScraper")
-    @patch("animator_credit_monitor.main.BangumiScraper")
-    @patch("animator_credit_monitor.main.HistoryManager")
-    def test_差分がない場合は通知が呼ばれない(
-        self,
-        mock_history_cls: MagicMock,
-        mock_bangumi_cls: MagicMock,
-        mock_wiki_cls: MagicMock,
-        mock_anilist_cls: MagicMock,
-        runner: CliRunner,
-        tmp_path: Path,
-    ) -> None:
-        mock_history = mock_history_cls.return_value
-        mock_history.detect_diff.return_value = []
-
-        mock_bangumi = mock_bangumi_cls.return_value
-        mock_bangumi.fetch_works.return_value = [{"id": "1", "title": "既存作品"}]
-
-        mock_wiki = mock_wiki_cls.return_value
-        mock_wiki.search.return_value = []
-
-        mock_anilist = mock_anilist_cls.return_value
-        mock_anilist.fetch_works.return_value = []
-
-        env = {
-            "TARGET_BANGUMI_ID": "12345",
-            "TARGET_NAME": "テスト",
-            "DATA_DIR": str(tmp_path),
-        }
-        with patch.dict("os.environ", env, clear=True):
-            result = runner.invoke(cli, ["check"])
-
-        assert result.exit_code == 0
-        assert "新しいクレジット" not in result.output
-
-    @patch("animator_credit_monitor.main.AniListScraper")
-    @patch("animator_credit_monitor.main.SakugaWikiScraper")
     @patch("animator_credit_monitor.main.BangumiScraper")
     @patch("animator_credit_monitor.main.HistoryManager")
     def test_dry_runオプションで状態が保存されない(
         self,
         mock_history_cls: MagicMock,
         mock_bangumi_cls: MagicMock,
-        mock_wiki_cls: MagicMock,
         mock_anilist_cls: MagicMock,
         runner: CliRunner,
         tmp_path: Path,
     ) -> None:
         mock_history = mock_history_cls.return_value
         mock_history.detect_diff.return_value = [{"id": "1", "title": "新作品", "role": "原画", "info": "2026-01"}]
-
-        mock_bangumi = mock_bangumi_cls.return_value
-        mock_bangumi.fetch_works.return_value = [{"id": "1", "title": "新作品", "role": "原画", "info": "2026-01"}]
-
-        mock_wiki = mock_wiki_cls.return_value
-        mock_wiki.search.return_value = []
-
-        mock_anilist = mock_anilist_cls.return_value
-        mock_anilist.fetch_works.return_value = []
+        mock_bangumi_cls.return_value.fetch_works.return_value = [{"id": "1", "title": "新作品"}]
+        mock_anilist_cls.return_value.fetch_works.return_value = []
 
         env = {
             "TARGET_BANGUMI_ID": "12345",
@@ -134,23 +83,18 @@ class TestCLI:
         mock_history.save.assert_not_called()
 
     @patch("animator_credit_monitor.main.AniListScraper")
-    @patch("animator_credit_monitor.main.SakugaWikiScraper")
     @patch("animator_credit_monitor.main.BangumiScraper")
     @patch("animator_credit_monitor.main.HistoryManager")
-    def test_bangumi_onlyオプションでwikiとAniListがスキップされる(
+    def test_bangumi_onlyオプションでAniListがスキップされる(
         self,
         mock_history_cls: MagicMock,
         mock_bangumi_cls: MagicMock,
-        mock_wiki_cls: MagicMock,
         mock_anilist_cls: MagicMock,
         runner: CliRunner,
         tmp_path: Path,
     ) -> None:
-        mock_history = mock_history_cls.return_value
-        mock_history.detect_diff.return_value = []
-
-        mock_bangumi = mock_bangumi_cls.return_value
-        mock_bangumi.fetch_works.return_value = []
+        mock_history_cls.return_value.detect_diff.return_value = []
+        mock_bangumi_cls.return_value.fetch_works.return_value = []
 
         env = {
             "TARGET_BANGUMI_ID": "12345",
@@ -161,37 +105,23 @@ class TestCLI:
             result = runner.invoke(cli, ["check", "--bangumi-only"])
 
         assert result.exit_code == 0
-        mock_wiki_cls.return_value.search.assert_not_called()
         mock_anilist_cls.return_value.fetch_works.assert_not_called()
 
     @patch("animator_credit_monitor.main.AniListScraper")
-    @patch("animator_credit_monitor.main.SakugaWikiScraper")
     @patch("animator_credit_monitor.main.BangumiScraper")
     @patch("animator_credit_monitor.main.HistoryManager")
-    def test_作画wiki失敗時にAniListにフォールバックする(
+    def test_nameベース監視はAniListを直接チェックする(
         self,
         mock_history_cls: MagicMock,
         mock_bangumi_cls: MagicMock,
-        mock_wiki_cls: MagicMock,
         mock_anilist_cls: MagicMock,
         runner: CliRunner,
         tmp_path: Path,
     ) -> None:
-        mock_history = mock_history_cls.return_value
-        anilist_item = {
-            "id": "1", "title": "AniList作品",
-            "role": "Key Animation", "date": "2026-01",
-        }
-        mock_history.detect_diff.return_value = [anilist_item]
-
-        mock_bangumi = mock_bangumi_cls.return_value
-        mock_bangumi.fetch_works.return_value = []
-
-        mock_wiki = mock_wiki_cls.return_value
-        mock_wiki.search.return_value = []  # wiki fails
-
-        mock_anilist = mock_anilist_cls.return_value
-        mock_anilist.fetch_works.return_value = [anilist_item]
+        anilist_item = {"id": "1", "title": "AniList作品", "role": "原画", "date": "2026-01"}
+        mock_history_cls.return_value.detect_diff.return_value = [anilist_item]
+        mock_bangumi_cls.return_value.fetch_works.return_value = []
+        mock_anilist_cls.return_value.fetch_works.return_value = [anilist_item]
 
         env = {
             "TARGET_BANGUMI_ID": "",
@@ -202,6 +132,155 @@ class TestCLI:
             result = runner.invoke(cli, ["check"])
 
         assert result.exit_code == 0
+        assert "Checking AniList" in result.output
         assert "AniList作品" in result.output
-        assert "falling back to AniList" in result.output
-        mock_anilist.fetch_works.assert_called_once_with("テスト")
+        assert "検知件数: 1" in result.output
+
+    @patch("animator_credit_monitor.main.EmailNotifier")
+    @patch("animator_credit_monitor.main.AniListScraper")
+    @patch("animator_credit_monitor.main.BangumiScraper")
+    @patch("animator_credit_monitor.main.HistoryManager")
+    def test_NOTIFIER_email設定でEmailNotifierが使われる(
+        self,
+        mock_history_cls: MagicMock,
+        mock_bangumi_cls: MagicMock,
+        mock_anilist_cls: MagicMock,
+        mock_email_notifier_cls: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        mock_history_cls.return_value.detect_diff.return_value = []
+        mock_bangumi_cls.return_value.fetch_works.return_value = []
+        mock_anilist_cls.return_value.fetch_works.return_value = []
+
+        env = {
+            "TARGET_BANGUMI_ID": "12345",
+            "TARGET_NAME": "テスト",
+            "DATA_DIR": str(tmp_path),
+            "NOTIFIER": "email",
+            "SMTP_HOST": "smtp.example.com",
+            "SMTP_PORT": "587",
+            "SMTP_FROM": "from@example.com",
+            "SMTP_TO": "to@example.com",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            result = runner.invoke(cli, ["check"])
+
+        assert result.exit_code == 0
+        mock_email_notifier_cls.assert_called_once()
+
+    @patch("animator_credit_monitor.main.LineNotifier")
+    @patch("animator_credit_monitor.main.AniListScraper")
+    @patch("animator_credit_monitor.main.BangumiScraper")
+    @patch("animator_credit_monitor.main.HistoryManager")
+    def test_NOTIFIER_line設定でLineNotifierが使われる(
+        self,
+        mock_history_cls: MagicMock,
+        mock_bangumi_cls: MagicMock,
+        mock_anilist_cls: MagicMock,
+        mock_line_notifier_cls: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        mock_history_cls.return_value.detect_diff.return_value = []
+        mock_bangumi_cls.return_value.fetch_works.return_value = []
+        mock_anilist_cls.return_value.fetch_works.return_value = []
+
+        env = {
+            "TARGET_BANGUMI_ID": "12345",
+            "TARGET_NAME": "テスト",
+            "DATA_DIR": str(tmp_path),
+            "NOTIFIER": "line",
+            "LINE_NOTIFY_TOKEN": "token",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            result = runner.invoke(cli, ["check"])
+
+        assert result.exit_code == 0
+        mock_line_notifier_cls.assert_called_once_with(
+            token="token",
+            api_url="https://notify-api.line.me/api/notify",
+            message_template="{title}\n{message}",
+        )
+
+    @patch("animator_credit_monitor.main.MultiNotifier")
+    @patch("animator_credit_monitor.main.LineNotifier")
+    @patch("animator_credit_monitor.main.EmailNotifier")
+    @patch("animator_credit_monitor.main.AniListScraper")
+    @patch("animator_credit_monitor.main.BangumiScraper")
+    @patch("animator_credit_monitor.main.HistoryManager")
+    def test_NOTIFIERSで複数通知を同時利用できる(
+        self,
+        mock_history_cls: MagicMock,
+        mock_bangumi_cls: MagicMock,
+        mock_anilist_cls: MagicMock,
+        mock_email_notifier_cls: MagicMock,
+        mock_line_notifier_cls: MagicMock,
+        mock_multi_notifier_cls: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        mock_history_cls.return_value.detect_diff.return_value = []
+        mock_bangumi_cls.return_value.fetch_works.return_value = []
+        mock_anilist_cls.return_value.fetch_works.return_value = []
+
+        env = {
+            "TARGET_NAME": "テスト",
+            "DATA_DIR": str(tmp_path),
+            "NOTIFIERS": "email,line",
+            "SMTP_HOST": "smtp.example.com",
+            "SMTP_PORT": "587",
+            "SMTP_FROM": "from@example.com",
+            "SMTP_TO": "to@example.com",
+            "LINE_NOTIFY_TOKEN": "token",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            result = runner.invoke(cli, ["check", "--anilist-only"])
+
+        assert result.exit_code == 0
+        mock_email_notifier_cls.assert_called_once()
+        mock_line_notifier_cls.assert_called_once()
+        mock_multi_notifier_cls.assert_called_once()
+
+    def test_NOTIFIER_email設定で必須環境変数不足時はエラー終了する(
+        self,
+        runner: CliRunner,
+    ) -> None:
+        env = {
+            "TARGET_NAME": "テスト",
+            "NOTIFIER": "email",
+            "SMTP_HOST": "smtp.example.com",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            result = runner.invoke(cli, ["check", "--anilist-only"])
+
+        assert result.exit_code != 0
+        assert "SMTP_HOST, SMTP_FROM, SMTP_TO" in result.output
+
+    def test_NOTIFIER_line設定でトークン不足時はエラー終了する(
+        self,
+        runner: CliRunner,
+    ) -> None:
+        env = {
+            "TARGET_NAME": "テスト",
+            "NOTIFIER": "line",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            result = runner.invoke(cli, ["check", "--anilist-only"])
+
+        assert result.exit_code != 0
+        assert "LINE_NOTIFY_TOKEN" in result.output
+
+    def test_NOTIFIER未知値でエラー終了する(
+        self,
+        runner: CliRunner,
+    ) -> None:
+        env = {
+            "TARGET_NAME": "テスト",
+            "NOTIFIER": "unknown",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            result = runner.invoke(cli, ["check", "--anilist-only"])
+
+        assert result.exit_code != 0
+        assert "Notifier type must be one of" in result.output

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -68,6 +68,23 @@ class TestNotifier:
         assert "本文メッセージ" in sent_msg.get_content()
 
     @patch("animator_credit_monitor.notifier.smtplib.SMTP")
+    def test_EmailNotifierでバックスラッシュnを改行として解釈する(self, mock_smtp_cls: MagicMock) -> None:
+        mock_smtp = MagicMock()
+        mock_smtp_cls.return_value.__enter__.return_value = mock_smtp
+
+        notifier = EmailNotifier(
+            host="smtp.example.com",
+            port=587,
+            from_addr="from@example.com",
+            to_addr="to@example.com",
+            body_template="{title}\\n\\n{message}",
+        )
+        notifier.notify("新規", "本文メッセージ")
+
+        sent_msg = mock_smtp.send_message.call_args.args[0]
+        assert "新規\n\n本文メッセージ" in sent_msg.get_content()
+
+    @patch("animator_credit_monitor.notifier.smtplib.SMTP")
     def test_EmailNotifierで未知のテンプレート変数はエラー(self, mock_smtp_cls: MagicMock) -> None:
         mock_smtp = MagicMock()
         mock_smtp_cls.return_value.__enter__.return_value = mock_smtp
@@ -126,6 +143,17 @@ class TestNotifier:
 
         kwargs = mock_post.call_args.kwargs
         assert kwargs["data"]["message"] == "[通知]タイトル => メッセージ"
+
+    @patch("animator_credit_monitor.notifier.requests.post")
+    def test_LineNotifierでバックスラッシュnを改行として解釈する(self, mock_post: MagicMock) -> None:
+        mock_resp = MagicMock()
+        mock_post.return_value = mock_resp
+
+        notifier = LineNotifier(token="token123", message_template="{title}\\n{message}")
+        notifier.notify("タイトル", "メッセージ")
+
+        kwargs = mock_post.call_args.kwargs
+        assert kwargs["data"]["message"] == "タイトル\nメッセージ"
 
     @patch("animator_credit_monitor.notifier.requests.post")
     def test_LineNotifierで未知のテンプレート変数はエラー(self, mock_post: MagicMock) -> None:

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,6 +1,8 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
 
-from animator_credit_monitor.notifier import ConsoleNotifier, Notifier
+from animator_credit_monitor.notifier import ConsoleNotifier, EmailNotifier, LineNotifier, MultiNotifier, Notifier
 
 
 class TestNotifier:
@@ -16,10 +18,120 @@ class TestNotifier:
         assert "テストタイトル" in captured.out
         assert "テストメッセージ" in captured.out
 
-    def test_コンソール通知でタイトルとメッセージが区別して表示される(self, capsys: pytest.CaptureFixture[str]) -> None:
-        notifier = ConsoleNotifier()
-        notifier.notify("新着クレジット", "作品Aに原画として参加")
+    def test_MultiNotifierで全通知先に配信される(self) -> None:
+        n1 = MagicMock()
+        n2 = MagicMock()
+        notifier = MultiNotifier([n1, n2])
 
-        captured = capsys.readouterr()
-        assert "新着クレジット" in captured.out
-        assert "作品Aに原画として参加" in captured.out
+        notifier.notify("title", "message")
+
+        n1.notify.assert_called_once_with("title", "message")
+        n2.notify.assert_called_once_with("title", "message")
+
+    @patch("animator_credit_monitor.notifier.smtplib.SMTP")
+    def test_EmailNotifierがSMTPで通知送信する(self, mock_smtp_cls: MagicMock) -> None:
+        mock_smtp = MagicMock()
+        mock_smtp_cls.return_value.__enter__.return_value = mock_smtp
+
+        notifier = EmailNotifier(
+            host="smtp.example.com",
+            port=587,
+            from_addr="from@example.com",
+            to_addr="to@example.com",
+            username="user",
+            password="pass",
+            use_tls=True,
+        )
+        notifier.notify("件名", "本文")
+
+        mock_smtp.starttls.assert_called_once()
+        mock_smtp.login.assert_called_once_with("user", "pass")
+        mock_smtp.send_message.assert_called_once()
+
+    @patch("animator_credit_monitor.notifier.smtplib.SMTP")
+    def test_EmailNotifierテンプレートが適用される(self, mock_smtp_cls: MagicMock) -> None:
+        mock_smtp = MagicMock()
+        mock_smtp_cls.return_value.__enter__.return_value = mock_smtp
+
+        notifier = EmailNotifier(
+            host="smtp.example.com",
+            port=587,
+            from_addr="from@example.com",
+            to_addr="to@example.com",
+            subject_template="[ACM] {title}",
+            body_template="---\n{title}\n---\n{message}",
+        )
+        notifier.notify("新規", "本文メッセージ")
+
+        sent_msg = mock_smtp.send_message.call_args.args[0]
+        assert sent_msg["Subject"] == "[ACM] 新規"
+        assert "本文メッセージ" in sent_msg.get_content()
+
+    @patch("animator_credit_monitor.notifier.smtplib.SMTP")
+    def test_EmailNotifierで未知のテンプレート変数はエラー(self, mock_smtp_cls: MagicMock) -> None:
+        mock_smtp = MagicMock()
+        mock_smtp_cls.return_value.__enter__.return_value = mock_smtp
+
+        notifier = EmailNotifier(
+            host="smtp.example.com",
+            port=587,
+            from_addr="from@example.com",
+            to_addr="to@example.com",
+            subject_template="{unknown}",
+        )
+
+        with pytest.raises(ValueError):
+            notifier.notify("件名", "本文")
+
+    @patch("animator_credit_monitor.notifier.smtplib.SMTP")
+    def test_EmailNotifierで認証情報なしならloginしない(self, mock_smtp_cls: MagicMock) -> None:
+        mock_smtp = MagicMock()
+        mock_smtp_cls.return_value.__enter__.return_value = mock_smtp
+
+        notifier = EmailNotifier(
+            host="smtp.example.com",
+            port=25,
+            from_addr="from@example.com",
+            to_addr="to@example.com",
+            use_tls=False,
+        )
+        notifier.notify("件名", "本文")
+
+        mock_smtp.starttls.assert_not_called()
+        mock_smtp.login.assert_not_called()
+        mock_smtp.send_message.assert_called_once()
+
+    @patch("animator_credit_monitor.notifier.requests.post")
+    def test_LineNotifierがAPIへ通知送信する(self, mock_post: MagicMock) -> None:
+        mock_resp = MagicMock()
+        mock_post.return_value = mock_resp
+
+        notifier = LineNotifier(token="token123")
+        notifier.notify("タイトル", "メッセージ")
+
+        mock_post.assert_called_once()
+        kwargs = mock_post.call_args.kwargs
+        assert kwargs["headers"]["Authorization"] == "Bearer token123"
+        assert "タイトル" in kwargs["data"]["message"]
+        assert "メッセージ" in kwargs["data"]["message"]
+        mock_resp.raise_for_status.assert_called_once()
+
+    @patch("animator_credit_monitor.notifier.requests.post")
+    def test_LineNotifierテンプレートが適用される(self, mock_post: MagicMock) -> None:
+        mock_resp = MagicMock()
+        mock_post.return_value = mock_resp
+
+        notifier = LineNotifier(token="token123", message_template="[通知]{title} => {message}")
+        notifier.notify("タイトル", "メッセージ")
+
+        kwargs = mock_post.call_args.kwargs
+        assert kwargs["data"]["message"] == "[通知]タイトル => メッセージ"
+
+    @patch("animator_credit_monitor.notifier.requests.post")
+    def test_LineNotifierで未知のテンプレート変数はエラー(self, mock_post: MagicMock) -> None:
+        mock_resp = MagicMock()
+        mock_post.return_value = mock_resp
+
+        notifier = LineNotifier(token="token123", message_template="{unknown}")
+        with pytest.raises(ValueError):
+            notifier.notify("タイトル", "メッセージ")


### PR DESCRIPTION
## 概要
  通知基盤を `console` だけでなく `email` / `line` に拡張し、複数通知先への同時配信（`NOTIFIERS`）に対応しました。
  あわせて通知メッセージ形式を標準化し、GitHub Actions による日次実行フローと運用ドキュメントを整備しています。

  ## 変更内容

  ### 1. 通知機能の拡張（feat）
  - `EmailNotifier` / `LineNotifier` / `MultiNotifier` を追加
  - 環境変数から通知先を構築する処理を `main.py` に実装
  - `NOTIFIER`（単一）と `NOTIFIERS`（複数）をサポート
  - 通知テンプレート変数 `{title}`, `{message}` を導入
  - 通知本文を標準化（`検知件数: N` + 連番形式）

  ### 2. CI/運用導線の追加（ci）
  - `.github/workflows/daily-credit-check.yml` を追加
  - GitHub Secrets 経由で通知設定を注入可能に
  - 自動実行手順を `docs/AUTOMATION.md`, `docs/AUTOMATION-JP.md` に追記
  - `templates/sendgrid_github_secrets.template.txt` を追加

  ### 3. ドキュメント更新（docs）
  - nameベース監視の実運用方針（AniList 直接利用）を明記
  - 通知バックエンドと通知メッセージ仕様を保守ドキュメントに追記
  - `CLAUDE.md` / `CLAUDE-JP.md` を実装内容に同期
  - `.env.example` / `README.md` を最新設定に更新
  - 通知テンプレート例を `templates/` に追加

  ## 影響範囲
  - 監視実行時の通知経路（console/email/line）
  - 環境変数設定（`SMTP_*`, `LINE_*`, `NOTIFIER(S)`）
  - GitHub Actions での定期実行運用

  ## テスト
  - `tests/test_notifier.py` を拡充（Email/Line/Multi + テンプレート/エラー系）
  - `tests/test_main.py` を更新（notifier選択、オプション分岐、設定エラー系）
